### PR TITLE
Upgrade mongoose to version 5.7.5 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "concurrently": "^4.1.2",
     "cookie-session": "^1.3.3",
     "express": "^4.17.1",
-    "mongoose": "^5.7.1",
+    "mongoose": ">=5.7.1",
     "nodemon": "^1.19.2",
     "passport": "^0.4.0",
     "passport-google-oauth20": "^2.0.0",


### PR DESCRIPTION
Automattic Mongoose through 5.7.4 allows attackers to bypass access control (in some applications) because any query object with a _bsontype attribute is ignored. For example, adding "_bsontype":"a" can sometimes interfere with a query filter. NOTE: this CVE is about Mongoose's failure to work around this _bsontype special case that exists in older versions of the bson parser (aka the mongodb/js-bson project).